### PR TITLE
Add Ustream embedded video support

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -58,7 +58,7 @@ module.exports = {
     videos: 'videos',
     audio: 'audio',
     fonts: 'fonts',
-    documents: 'documents',
+    documents: 'docs',
   },
   sourcemaps: {
     enable: true,

--- a/config/default.js
+++ b/config/default.js
@@ -58,7 +58,7 @@ module.exports = {
     videos: 'videos',
     audio: 'audio',
     fonts: 'fonts',
-    documents: 'docs',
+    documents: 'documents',
   },
   sourcemaps: {
     enable: true,

--- a/lib/helpers/markdown/plugins/video.js
+++ b/lib/helpers/markdown/plugins/video.js
@@ -90,9 +90,15 @@ function render(tokens) {
       embedURL = `//player.vimeo.com/video/${uri.path.split('/').pop()}`;
     }
 
-    // Ustream URL
+    // Ustream URLs (support both channel and recorded URLs)
     else if (uri.hostname === 'www.ustream.tv') {
-      embedURL = `http://www.ustream.tv/embed/recorded/${uri.path.split('/').pop()}`;
+      if (uri.path.split('/')[1] === 'channel') {
+        embedURL = `https://www.ustream.tv/embed/${uri.path.split('/').pop()}?html5ui`;
+      }
+
+      else {
+        embedURL = `https://www.ustream.tv/embed/recorded/${uri.path.split('/').pop()}?html5ui`;
+      }
     }
 
     output += `<iframe  src="${embedURL}" width="560" height="315" frameborder="0" allowfullscreen></iframe>`;

--- a/lib/helpers/markdown/plugins/video.js
+++ b/lib/helpers/markdown/plugins/video.js
@@ -90,6 +90,11 @@ function render(tokens) {
       embedURL = `//player.vimeo.com/video/${uri.path.split('/').pop()}`;
     }
 
+    // Ustream URL
+    else if (uri.hostname === 'www.ustream.tv') {
+      embedURL = `http://www.ustream.tv/embed/recorded/${uri.path.split('/').pop()}`;
+    }
+
     output += `<iframe  src="${embedURL}" width="560" height="315" frameborder="0" allowfullscreen></iframe>`;
 
     output += '</div>';

--- a/tests/lib/markdown.js
+++ b/tests/lib/markdown.js
@@ -75,10 +75,18 @@ test('Video Plugin - Renders Vimeo', t => {
   t.is(output, expected, 'Vimeo Embed');
 });
 
-test('Video Plugin - Renders Ustream', t => {
-  const sample = '@[http://www.ustream.tv/embed/22046713?html5ui]';
+test('Video Plugin - Renders Ustream (channel)', t => {
+  const sample = '@[https://www.ustream.tv/channel/22046713]';
   const output = md.render(sample);
-  const expected = '<p><div class="flexible-video"><iframe  src="http://www.ustream.tv/embed/recorded/22046713?html5ui" width="560" height="315" frameborder="0" allowfullscreen></iframe></div></p>\n';
+  const expected = '<p><div class="flexible-video"><iframe  src="https://www.ustream.tv/embed/22046713?html5ui" width="560" height="315" frameborder="0" allowfullscreen></iframe></div></p>\n';
+
+  t.is(output, expected, 'Ustream Embed');
+});
+
+test('Video Plugin - Renders Ustream (recorded)', t => {
+  const sample = '@[https://www.ustream.tv/recorded/92458394]';
+  const output = md.render(sample);
+  const expected = '<p><div class="flexible-video"><iframe  src="https://www.ustream.tv/embed/recorded/92458394?html5ui" width="560" height="315" frameborder="0" allowfullscreen></iframe></div></p>\n';
 
   t.is(output, expected, 'Ustream Embed');
 });

--- a/tests/lib/markdown.js
+++ b/tests/lib/markdown.js
@@ -74,3 +74,11 @@ test('Video Plugin - Renders Vimeo', t => {
 
   t.is(output, expected, 'Vimeo Embed');
 });
+
+test('Video Plugin - Renders Ustream', t => {
+  const sample = '@[http://www.ustream.tv/embed/22046713?html5ui]';
+  const output = md.render(sample);
+  const expected = '<p><div class="flexible-video"><iframe  src="http://www.ustream.tv/embed/recorded/22046713?html5ui" width="560" height="315" frameborder="0" allowfullscreen></iframe></div></p>\n';
+
+  t.is(output, expected, 'Ustream Embed');
+});


### PR DESCRIPTION
Gulp armadillo supports multimedia embedding for Youtube and Vimeo. As a Ustream account user, I would like to be able to embed videos already hosted on Ustream.

---
Resolves #209 

`DCO 1.1 Signed-off-by: Kelly Churchill <kchurchill.tx@gmail.com>`
