### PR TITLE
Hotfix/sw babel

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -14,14 +14,6 @@ module.exports = {
       rollupCommon(),
     ],
   },
-  babel: {
-    presets: [
-      'babili',
-    ],
-    comments: false,
-    minified: true,
-    compact: true,
-  },
   eslint: {},
   sass: {
     outputStyle: 'compressed',

--- a/config/default.js
+++ b/config/default.js
@@ -94,7 +94,6 @@ module.exports = {
         'js:watch',
         'pages:watch',
         'sass:watch',
-        'sw:watch',
       ],
     ],
     copy: [
@@ -115,7 +114,6 @@ module.exports = {
         'pages',
         'sass',
       ],
-      'sw',
     ],
     serve: [
       'build',
@@ -127,6 +125,7 @@ module.exports = {
     dry: [
       'build',
       'optimize',
+      'sw',
     ],
     deploy: [
       'deploy:dry',

--- a/lib/tasks/scripts.js
+++ b/lib/tasks/scripts.js
@@ -18,7 +18,6 @@ const path = require('path');
 
 module.exports.compile = file => {
   const rollupOptions = clone(config.get('rollup'));
-  const babelOptions = config.get('babel');
 
   let entry = rollupOptions.entry;
 
@@ -38,7 +37,14 @@ module.exports.compile = file => {
     maps.init({
       loadMaps: true,
     }),
-    babel(babelOptions),
+    babel({
+      presets: [
+        'babili',
+      ],
+      comments: false,
+      minified: true,
+      compact: true,
+    }),
     maps.write(config.sourcemaps.directory),
   ]);
 };


### PR DESCRIPTION
* Ensures SW only generated on `deploy:dry` instead of watching so BrowserSync doesn't crap out
* :boom: Removes user-configurable Babel, now has hard-coded Babili configuration post-Rollup compile

---
Resolves #217 
Resolves #218 

`DCO 1.1 Signed-off-by: Sam Richard <sam@snug.ug>`
