### PR TITLE
sass-linting throws error

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,3 @@
+rules:
+  no-color-keywords:
+    - 2

--- a/lib/tasks/sass.js
+++ b/lib/tasks/sass.js
@@ -17,4 +17,5 @@ module.exports.compile = lazypipe()
 
 module.exports.lint = lazypipe()
   .pipe(lint)
-  .pipe(lint.format);
+  .pipe(lint.format)
+  .pipe(lint.failOnError);

--- a/tests/tasks/sass.js
+++ b/tests/tasks/sass.js
@@ -42,3 +42,17 @@ test('Import Once', t => {
       t.is(output.contents.toString(), expected, 'Sass compiled as expected');
     });
 });
+
+test('Sass-lint triggers error', t => {
+  const input = './tests/fixtures/sass/_partial.scss';
+  const expected = {
+    message: '1 errors detected in _partial.scss',
+    plugin: 'sass-lint',
+  };
+
+  return fromPath(input, sass.lint)
+    .catch(error => {
+      t.is(error.message, expected.message, 'sass linting returns error message');
+      t.is(error.plugin, expected.plugin, 'error knows plugin');
+    });
+});


### PR DESCRIPTION
Fixes a bug where sass lint errors are not going through the `failure` function

---
Resolves #250 

`DCO 1.1 Signed-off-by: Scott Nath <github@scottnath.com>`
